### PR TITLE
Fix Responder future type

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ async fn example_handler(req: HttpRequest) -> impl Responder {
     let props = ExampleProps {
         key: "value".to_string(),
     };
-    InertiaResponder::new("ExampleComponent", props).respond_to(&req)
+    InertiaResponder::new("ExampleComponent", props)
+        .respond_to(&req)
+        .await
 }
 
 #[actix_web::main]

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -14,7 +14,7 @@ async fn hello(req: HttpRequest) -> impl Responder {
         message: "this is my message from Rust :)".to_string(),
     };
     if req.headers().contains_key("x-inertia") {
-        InertiaResponder::new("Hello", props).respond_to(&req)
+        InertiaResponder::new("Hello", props).respond_to(&req).await
     } else {
         response_with_html(&req, props, "Hello".to_string())
     }
@@ -25,7 +25,7 @@ async fn world(req: HttpRequest) -> impl Responder {
         message: "this is my message from Rust :) sceond page".to_string(),
     };
     if req.headers().contains_key("x-inertia") {
-        InertiaResponder::new("World", props).respond_to(&req)
+        InertiaResponder::new("World", props).respond_to(&req).await
     } else {
         response_with_html(&req, props, "World".to_string())
     }
@@ -36,7 +36,7 @@ async fn version(req: HttpRequest) -> impl Responder {
         message: "this is my message from Rust :) with Version 1".to_string(),
     };
     if req.headers().contains_key("x-inertia") {
-        InertiaResponder::new("VersionPage", props).respond_to(&req)
+        InertiaResponder::new("VersionPage", props).respond_to(&req).await
     } else {
         response_with_html(&req, props, "VersionPage".to_string())
     }

--- a/src/inertia_responder.rs
+++ b/src/inertia_responder.rs
@@ -1,4 +1,5 @@
 use actix_web::{HttpRequest, HttpResponse, Responder};
+use futures_util::future::LocalBoxFuture;
 use serde::Serialize;
 
 use crate::Inertia;
@@ -17,14 +18,21 @@ impl<T: Serialize> InertiaResponder<T> {
     }
 }
 
-impl<T: Serialize> Responder for InertiaResponder<T> {
+impl<T> Responder for InertiaResponder<T>
+where
+    T: Serialize + 'static,
+{
     type Body = actix_web::body::BoxBody;
+    type Future<'a> = LocalBoxFuture<'a, HttpResponse<Self::Body>> where Self: 'a;
 
-    fn respond_to(self, req: &HttpRequest) -> HttpResponse<Self::Body> {
-        let inertia = Inertia::new(self.component, self.props, req.uri().to_string());
+    fn respond_to(self, req: &HttpRequest) -> Self::Future<'_> {
+        let req = req.clone();
+        let component = self.component;
+        let props = self.props;
 
-        let response = futures::executor::block_on(async { inertia.into_response(req).await });
-
-        response
+        Box::pin(async move {
+            let inertia = Inertia::new(component, props, req.uri().to_string());
+            inertia.into_response(&req).await
+        })
     }
 }


### PR DESCRIPTION
## Summary
- fix `InertiaResponder` to implement `Responder` with a generic `Future` type

## Testing
- `cargo test` *(fails to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6873829002f88321b6331ec31b4e8103