### PR TITLE
Refactor InertiaResponder to be async

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To use the version middleware, include it in your Actix app setup as shown above
 An example handler that uses Inertia:
 
 ```rust
-use actix_inertia::{InertiaResponder, VersionMiddleware};
+use actix_inertia::{inertia_responder::InertiaResponder, VersionMiddleware};
 use actix_web::{web, App, HttpRequest, HttpServer, Responder};
 use serde::Serialize;
 
@@ -77,7 +77,7 @@ async fn example_handler(req: HttpRequest) -> impl Responder {
     let props = ExampleProps {
         key: "value".to_string(),
     };
-    InertiaResponder::new("ExampleComponent", props).respond_to(&req)
+    InertiaResponder::new("ExampleComponent", props).respond_to(&req).await
 }
 
 #[actix_web::main]

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -14,7 +14,7 @@ async fn hello(req: HttpRequest) -> impl Responder {
         message: "this is my message from Rust :)".to_string(),
     };
     if req.headers().contains_key("x-inertia") {
-        InertiaResponder::new("Hello", props).respond_to(&req)
+        InertiaResponder::new("Hello", props).respond_to(&req).await
     } else {
         response_with_html(&req, props, "Hello".to_string())
     }
@@ -25,7 +25,7 @@ async fn world(req: HttpRequest) -> impl Responder {
         message: "this is my message from Rust :) sceond page".to_string(),
     };
     if req.headers().contains_key("x-inertia") {
-        InertiaResponder::new("World", props).respond_to(&req)
+        InertiaResponder::new("World", props).respond_to(&req).await
     } else {
         response_with_html(&req, props, "World".to_string())
     }
@@ -36,7 +36,9 @@ async fn version(req: HttpRequest) -> impl Responder {
         message: "this is my message from Rust :) with Version 1".to_string(),
     };
     if req.headers().contains_key("x-inertia") {
-        InertiaResponder::new("VersionPage", props).respond_to(&req)
+        InertiaResponder::new("VersionPage", props)
+            .respond_to(&req)
+            .await
     } else {
         response_with_html(&req, props, "VersionPage".to_string())
     }

--- a/src/inertia_responder.rs
+++ b/src/inertia_responder.rs
@@ -1,4 +1,4 @@
-use actix_web::{HttpRequest, HttpResponse, Responder};
+use actix_web::{HttpRequest, HttpResponse};
 use serde::Serialize;
 
 use crate::Inertia;
@@ -15,16 +15,10 @@ impl<T: Serialize> InertiaResponder<T> {
             props,
         }
     }
-}
 
-impl<T: Serialize> Responder for InertiaResponder<T> {
-    type Body = actix_web::body::BoxBody;
-
-    fn respond_to(self, req: &HttpRequest) -> HttpResponse<Self::Body> {
+    pub async fn respond_to(self, req: &HttpRequest) -> HttpResponse {
         let inertia = Inertia::new(self.component, self.props, req.uri().to_string());
 
-        let response = futures::executor::block_on(async { inertia.into_response(req).await });
-
-        response
+        inertia.into_response(req).await
     }
 }


### PR DESCRIPTION
## Summary
- refactor `InertiaResponder` to provide an async `respond_to` API
- update example and README to await the responder

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b41cda12f48321a9bc4d77fde89a22